### PR TITLE
GUI: Populating dock widgets in a more generic way

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -9,7 +9,7 @@ jobs:
   style:
     name: Style Check
     runs-on: ubuntu-latest
-    if: github.repository == 'royerlab/coPylot'
+    if: github.repository == 'czbiohub/coPylot'
 
     strategy:
       matrix:
@@ -33,7 +33,7 @@ jobs:
   lint:
       name: Lint Check
       runs-on: ubuntu-latest
-      if: github.repository == 'royerlab/coPylot'
+      if: github.repository == 'czbiohub/coPylot'
 
       strategy:
         matrix:
@@ -57,7 +57,7 @@ jobs:
     needs: [ style, lint ]
     name: Tests
     runs-on: ubuntu-latest
-    if: github.repository == 'royerlab/coPylot'
+    if: github.repository == 'czbiohub/coPylot'
 
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ have `pip`.
 #### Clone coPylot Repository
 
 ```
-git clone https://github.com/royerlab/coPylot.git
+git clone https://github.com/czbiohub/coPylot.git
 ```
 
 #### Create Conda Environment and Install coPylot 
@@ -37,7 +37,7 @@ pip install -e .
 
 ## Documentation
 
-coPylot documentation can be found [here](https://royerlab.github.io/coPylot/).
+coPylot documentation can be found [here](https://czbiohub.github.io/coPylot/).
 
 
 ## Contributing

--- a/copylot/gui/gui.py
+++ b/copylot/gui/gui.py
@@ -99,7 +99,7 @@ class MainWindow(QMainWindow):
             ("timelapse_control", [self, self.threadpool]),
             ("water_dispenser", [self, self.threadpool]),
             ("laser", [self]),
-            ("parameters", [self])
+            ("parameters", [self]),
         ]
 
         for name, args in self.dock_widgets_to_initialize:
@@ -113,16 +113,16 @@ class MainWindow(QMainWindow):
         # initialize widgets and assign to their dock
         for idx, (name, args) in enumerate(self.dock_widgets_to_initialize):
             self.dock_list[idx].setWidget(
-                DockPlaceholder(
-                    self, self.dock_list[idx], name, args
-                )
+                DockPlaceholder(self, self.dock_list[idx], name, args)
             )
 
         for idx, dock in enumerate(self.dock_list):
             if idx == 0:
                 self.addDockWidget(Qt.LeftDockWidgetArea, self.dock_list[idx])
             else:
-                self.splitDockWidget(self.dock_list[idx-1], self.dock_list[idx], Qt.Vertical)
+                self.splitDockWidget(
+                    self.dock_list[idx - 1], self.dock_list[idx], Qt.Vertical
+                )
 
         # create status bar that is updated from live and timelapse control classes
         self.status_bar = QStatusBar()

--- a/copylot/gui/gui.py
+++ b/copylot/gui/gui.py
@@ -94,68 +94,35 @@ class MainWindow(QMainWindow):
         self.dock_list = []
 
         # initialize docks
-        self.live_dock = QDockWidget(self)
-        self.live_dock.setTitleBarWidget(QLabel("Live Mode"))
-        self.dock_list.append(self.live_dock)
+        self.dock_widgets_to_initialize = [
+            ("live_control", [self, self.threadpool]),
+            ("timelapse_control", [self, self.threadpool]),
+            ("water_dispenser", [self, self.threadpool]),
+            ("laser", [self]),
+            ("parameters", [self])
+        ]
 
-        self.timelapse_dock = QDockWidget(self)
-        self.timelapse_dock.setTitleBarWidget(QLabel("Timelapse Mode"))
-        self.dock_list.append(self.timelapse_dock)
-
-        self.water_dock = QDockWidget(self)
-        self.water_dock.setTitleBarWidget(QLabel("Water Dispenser"))
-        self.dock_list.append(self.water_dock)
-
-        self.parameters_dock = QDockWidget(self)
-        self.parameters_dock.setTitleBarWidget(QLabel("NI DAQ Parameters"))
-        self.dock_list.append(self.parameters_dock)
-
-        self.laser_dock = QDockWidget(self)
-        self.laser_dock.setTitleBarWidget(QLabel("Laser"))
-        self.dock_list.append(self.laser_dock)
+        for name, args in self.dock_widgets_to_initialize:
+            dock_widget = QDockWidget(self)
+            dock_widget.setTitleBarWidget(QLabel(name))
+            self.dock_list.append(dock_widget)
 
         for dock in self.dock_list:
             _apply_dock_config(dock)
 
         # initialize widgets and assign to their dock
-        self.live_dock.setWidget(
-            DockPlaceholder(
-                self, self.live_dock, "live_control", [self, self.threadpool]
+        for idx, (name, args) in enumerate(self.dock_widgets_to_initialize):
+            self.dock_list[idx].setWidget(
+                DockPlaceholder(
+                    self, self.dock_list[idx], name, args
+                )
             )
-        )
-        # self.addDockWidget(Qt.RightDockWidgetArea, self.live_dock)
-        #
-        # self.timelapse_widget = TimelapseControl(self, self.threadpool)
-        self.timelapse_dock.setWidget(
-            DockPlaceholder(
-                self, self.timelapse_dock, "timelapse_control", [self, self.threadpool]
-            )
-        )
-        # self.addDockWidget(Qt.RightDockWidgetArea, self.timelapse_dock)
 
-        # self.water_widget = WaterDispenser(self, self.threadpool)
-        self.water_dock.setWidget(
-            DockPlaceholder(
-                self, self.water_dock, "water_dispenser", [self, self.threadpool]
-            )
-        )
-        # self.addDockWidget(Qt.RightDockWidgetArea, self.water_dock)
-        self.laser_dock.setWidget(
-            DockPlaceholder(self, self.laser_dock, "laser", [self])
-        )
-
-        # self.parameters_widget = ParametersDockWidget(self)
-        self.parameters_placeholder = DockPlaceholder(
-            self, self.parameters_dock, "parameters", [self]
-        )
-        self.parameters_dock.setWidget(self.parameters_placeholder)
-        self.addDockWidget(Qt.LeftDockWidgetArea, self.parameters_dock)
-
-        # split horizontal and vertical space between docks
-        self.splitDockWidget(self.parameters_dock, self.live_dock, Qt.Horizontal)
-        self.splitDockWidget(self.live_dock, self.timelapse_dock, Qt.Vertical)
-        self.splitDockWidget(self.timelapse_dock, self.water_dock, Qt.Vertical)
-        self.splitDockWidget(self.water_dock, self.laser_dock, Qt.Vertical)
+        for idx, dock in enumerate(self.dock_list):
+            if idx == 0:
+                self.addDockWidget(Qt.LeftDockWidgetArea, self.dock_list[idx])
+            else:
+                self.splitDockWidget(self.dock_list[idx-1], self.dock_list[idx], Qt.Vertical)
 
         # create status bar that is updated from live and timelapse control classes
         self.status_bar = QStatusBar()

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -8,7 +8,7 @@ coPylot with the help of following commands:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/royerlab/coPylot.git
+    $ git clone https://github.com/czbiohub/coPylot.git
     $ cd coPylot
     $ pip install -e .
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ install editable version of coPylot with help of `pip`:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/royerlab/coPylot.git
+    $ git clone https://github.com/czbiohub/coPylot.git
     $ cd coPylot
     $ pip install -e .
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = copylot
-url = https://royerlab.github.io/copylot/
-download_url = https://github.com/royerlab/copylot
+url = https://czbiohub.github.io/copylot/
+download_url = https://github.com/czbiohub/copylot
 license = BSD 3-Clause
 license_file = LICENSE.txt
 description =  coPylot - microscope control


### PR DESCRIPTION
This PR introduces a more generic way to populate dock widgets on the main GUI, the main motivation behind this to make it easier for new dockable widget developers to test and integrate their widgets.