### PR TITLE
MAINT: Fix black version

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black
+          pip install black==22.12.0
       - name: Check code styling with Black
         run: |
           black --diff -S -t py39 copylot

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,4 @@
-black>=22.1.0
+black==22.12.0
 flake8>=4.0.1
 notebook==6.4.12
 pytest>=6.2.5


### PR DESCRIPTION
With introduced style 2023, latest black version requires a huge repo-wide reformatting. To prevent that, we are fixing black to latest style 2022 version.