### PR TITLE
Add a GitHub Actions workflow to build and publish the docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,55 @@
+# Workflow to build the docs (with sphinx) and deploy the build to GitHub Pages
+# note: parts of this workflow were copied directly from GitHub's suggested workflows
+name: Build and deploy docs
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Install dependencies
+        working-directory: ./docs
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-docs.txt
+      - name: Build the docs
+        working-directory: ./docs
+        run: make build
+      - name: Upload build artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './docs/build/html'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 
-html:
+build:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,5 @@
+numpydoc==1.1.0
+sphinx==4.2.0
+sphinx-rtd-theme==1.0.0
+sphinx-copybutton==0.4.0
+sphinx-multiversion==0.2.4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,16 @@ numpydoc_show_class_members = True
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
+html_sidebars = {
+    '**': [
+        'versions.html',
+    ],
+}
+
+# for now, only target the main branch (and ignore tags)
+smv_branch_whitelist = 'main'
+# smv_tag_whitelist = r'^v\d+\.\d+\.\d+$'
+
 # The suffix of source filenames.
 source_suffix = ".rst"
 


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build and publish the docs to the repo's GitHub Pages site (which is `czbiohub.github.io/copylot`). The action is triggered on pushes to `main` and can also be triggered manually from the 'Actions' tab of the repo's main github page. 

Note that in order for this workflow to be triggered, it must first be merged into `main`, and then a repo admin must set the 'source' for the repo's pages site to 'github actions' (instead of 'deploy from a branch'). This setting is in the 'pages' section of the repo settings. 

Note that using github actions to deploy static assets to github pages is [still in beta](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow). I tested this workflow on my fork and it appears to work as expected. 

