### PR TITLE
black and flake8 exclude infra

### DIFF
--- a/copylot/hardware/mirrors/optotune/demo/demo_mirror.py
+++ b/copylot/hardware/mirrors/optotune/demo/demo_mirror.py
@@ -29,7 +29,7 @@ def demo_spiral_scan():
     theta = numpy.linspace(0, 20 * numpy.pi, 500)
     positions = []
     for theta in theta:
-        r = theta * .005
+        r = theta * 0.005
         positions.append((r * numpy.cos(theta), r * numpy.sin(theta)))
 
     for position in positions:

--- a/copylot/hardware/mirrors/optotune/mirror.py
+++ b/copylot/hardware/mirrors/optotune/mirror.py
@@ -18,7 +18,9 @@ class OptoMirror:
 
         """
         self.mirror = optoMDC.connect(
-            com_port if com_port is not None else optoMDC.tools.list_comports.get_mre2_port()
+            com_port
+            if com_port is not None
+            else optoMDC.tools.list_comports.get_mre2_port()
         )
 
         self.channel_x = self.mirror.Mirror.Channel_0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
 target-version = ['py36', 'py37']
 skip-string-normalization = true
+exclude = '''(copylot/hardware/mirrors/optotune/optoMDC)'''
 
 [build-system]
 requires = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[flake8]
+extend-ignore = E203, E501, W503
+exclude = .github,__pycache__,docs/source/conf.py,old,build,dist, copylot/hardware/mirrors/optotune/optoMDC
+max-complexity = 10


### PR DESCRIPTION
This PR introduces `tox.ini` file to configure flake8 details and exclude folder path property for black in `pyproject.toml` file. Also, it addresses the style issues merged in #147 .