### PR TITLE
Add pylint to CI and improve dev infra

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -48,10 +48,13 @@ jobs:
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip
-            pip install flake8==4.0.1
+            pip install -r requirements/development.txt
         - name: Check code with Flake8
           run: |
-            flake8 --ignore E501,E203,E731,E741,W503 copylot
+            flake8 copylot
+        - name: Check code with pylint
+          run: |
+            pylint coyplot
 
   test-linux:
     needs: [ style, lint ]

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -54,7 +54,7 @@ jobs:
             flake8 copylot
         - name: Check code with pylint
           run: |
-            pylint coyplot
+            pylint copylot
 
   test-linux:
     needs: [ style, lint ]

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -49,6 +49,7 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             pip install -r requirements/development.txt
+            pip install -e .
         - name: Check code with Flake8
           run: |
             flake8 copylot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,13 +78,20 @@ conda activate copylot
 # Install coPylot and dev dependencies
 make setup-develop
 
-# Before making a PR make sure tests are passing
-# To run tests
+# Optionally install the pre-commit hooks (which currently just run `black`)
+pre-commit install
+
+# Before making a PR, make sure tests are passing
 make test
 
-# Before making a PR also check if your branch passes style guidelines and linting
+# Before making a PR, check that your branch passes linting 
+# and adheres to black's style guidelines
 make check-format
 make lint
+
+# if pre-commit hooks are not installed and your branch does not meet black's style,
+# run `black` manually to format your branch
+make format
 ```
 
 ##### For PyCharm users:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,20 +75,16 @@ conda create -n copylot python=3.9
 # Activate the environment
 conda activate copylot
 
-# Install coPylot
-pip install -e .
-
-# Install developmental dependencies
-pip install -r requirements/development.txt
+# Install coPylot and dev dependencies
+make setup-develop
 
 # Before making a PR make sure tests are passing
 # To run tests
-python -m pytest . --disable-pytest-warnings
+make test
 
-# Before making a PR also check if your branch
-# passes style guidelines
-black --check -S -t py39 .
-flake8 --ignore E501,E203,E731,E741,W503 copylot
+# Before making a PR also check if your branch passes style guidelines and linting
+make check-format
+make lint
 ```
 
 ##### For PyCharm users:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ PACKAGE_NAME := copylot
 setup-develop:
 	pip install -r requirements/development.txt
 	pip install -e .
-	pre-commit install
 
 .PHONY: uninstall
 uninstall:
@@ -14,12 +13,17 @@ uninstall:
 check-format:
 	black --check -S -t py39 .
 
+.PHONY: format
+format:
+	black -S -t py39 .
+
 .PHONY: lint
 lint:
 	flake8 $(PACKAGE_NAME)
 	pylint $(PACKAGE_NAME)
 
 # run the pre-commit hooks on all files (not just staged changes)
+# (requires pre-commit to be installed)
 .PHONY: pre-commit
 pre-commit:
 	pre-commit run --all-files

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+PACKAGE_NAME := copylot
+
+.PHONY: setup-develop
+setup-develop:
+	pip install -r requirements/development.txt
+	pip install -e .
+	pre-commit install
+
+.PHONY: uninstall
+uninstall:
+	pip uninstall -y $(PACKAGE_NAME)
+
+.PHONY: check-format
+check-format:
+	black --check -S -t py39 .
+
+.PHONY: lint
+lint:
+	flake8 $(PACKAGE_NAME)
+	pylint $(PACKAGE_NAME)
+
+# run the pre-commit hooks on all files (not just staged changes)
+.PHONY: pre-commit
+pre-commit:
+	pre-commit run --all-files
+
+.PHONY: test
+test:
+	python -m pytest . --disable-pytest-warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,9 @@ requires = [
 
 [tool.setuptools_scm]
 write_to = "copylot/_version.py"
+
+[tool.pylint]
+# disable all conventions, refactors, warnings (C, R, W) and the following rules:
+# - E1136: 'unsubscriptable-object' (anecdotal false positives for numpy objects)
+disable = ["C", "R", "W", "unsubscriptable-object"]
+ignore-paths = '''(copylot/hardware/mirrors/optotune/optoMDC/*)'''

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,5 +1,6 @@
 black==22.12.0
-flake8>=4.0.1
+flake8==4.0.1
 notebook==6.4.12
+pylint==2.17.0
 pytest>=6.2.5
 pre-commit>=2.15.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,23 @@
 [flake8]
-extend-ignore = E203, E501, W503
-exclude = .github,__pycache__,docs/source/conf.py,old,build,dist, copylot/hardware/mirrors/optotune/optoMDC
+extend-ignore = 
+    # line too long (line length is handled by black)
+    E501,
+    # whitespace before ':' (may conflict w black)
+    E203,
+    # no lambdas
+    E731,
+    # no variables named 'I', 'O', or 'L'
+    E741,
+    # line break before a binary operator
+    W503
+
+exclude = 
+    .github,
+    __pycache__,
+    docs/source/conf.py,
+    old,
+    build,
+    dist,
+    copylot/hardware/mirrors/optotune/optoMDC
+
 max-complexity = 10


### PR DESCRIPTION
This PR addresses #153 by adding pylint to the development workflow and to the CI that runs on PRs. It also adds a makefile to define common development tasks (running black, linting, and tests) and clarifies the flake8 config. 